### PR TITLE
fix: makeSortable should call makesortable JS method (lowercase)

### DIFF
--- a/sortable_column.py
+++ b/sortable_column.py
@@ -22,4 +22,4 @@ class SortableColumn(ui.element, component='sortable_column.js'):
             print(e.args)
 
     def makeSortable(self) -> None:
-        self.run_method('makeSortable')
+        self.run_method('makesortable')


### PR DESCRIPTION
The `makeSortable` method from the Python component called the JS method `makeSortable`,
but it is declared as `makesortable` (in lowercase) in `sortable_column.js`.
This PR fixes the call to 
```
self.run_method('makesortable')
```
to avoid the ReferenceError: makeSortable is not defined error.